### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,7 +70,7 @@ Testkit is a Go module providing a modular builder framework to streamline test 
 - `cmd/example/main.go` -- example application demonstrating all features
 - `pkg/test/*.go` -- main library files (builder.go, factory.go, examples.go, doc.go)
 - `pkg/test/*_test.go` -- comprehensive test files with 95.9% coverage
-- `go.mod` -- module definition (requires Go 1.26.0+)
+- `go.mod` -- module definition (requires Go 1.26.3+)
 - `Makefile` -- build targets provided via shared pipeline makefiles
 - `README.md` -- project documentation and usage examples
 - `CHANGELOG.md` -- version history and release notes
@@ -195,7 +195,7 @@ go 1.26.3
 
 **Build failures:**
 - Run `go mod tidy` to fix dependency issues
-- Check Go version is 1.26.0+
+- Check Go version is 1.26.3+
 
 **Test failures:**  
 - Ensure no validation logic changes without updating tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to fix stale Go version references (`1.26.0+` → `1.26.3+`)
+
 ## [0.2.1] - 2026-05-08
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.